### PR TITLE
Bump api-gatway module verision (cf cookie forward)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,8 @@ module "aws_gateway" {
   api_dns   = "${var.domain}"
   api_alias = "${var.domain_alias}"
 
+  validate_cert = true
+
   loadbalancers = [
     "${module.aws_deploy-api_uat-eu-north-1.gateway_lb_dns}",
   ]

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ module "aws_deploy-api_uat-eu-north-1" {
 }
 
 module "aws_gateway" {
-  source    = "github.com/aeternity/terraform-aws-api-gateway?ref=v1.0.0"
+  source    = "github.com/aeternity/terraform-aws-api-gateway?ref=v1.1.0"
   dns_zone  = "${var.dns_zone}"
   api_dns   = "${var.domain}"
   api_alias = "${var.domain_alias}"


### PR DESCRIPTION
Use v1.1.0 which enables the LB cookie forwarding in cloudfront

in scope of https://www.pivotaltracker.com/story/show/164978300

Notes:
Because of terraform 0.11 limitation, certificate validation can not be toggled with a variable. Resource is required even if not really used when defined in a ternary check.
More specifically `"${var.validate_cert ? aws_acm_certificate_validation.cert.certificate_arn : aws_acm_certificate.cert.arn}"`
ref: https://www.hashicorp.com/blog/terraform-0-12-conditional-operator-improvements#conditionally-omitted-argumentshttps://www.hashicorp.com/blog/terraform-0-12-conditional-operator-improvements#conditionally-omitted-arguments

So we turn on the certificate validation routine although the certificate is manually validated in a outside service

Probably we need to migrate to terraform 0.12