### PR TITLE
Update gw module to v2.0.0

### DIFF
--- a/aws.tf
+++ b/aws.tf
@@ -8,13 +8,13 @@ terraform {
 }
 
 provider "aws" {
-  version = "1.55"
+  version = "2.16.0"
   region  = "us-east-1"
   alias   = "us-east-1"
 }
 
 provider "aws" {
-  version = "1.55"
+  version = "2.16.0"
   region  = "eu-north-1"
   alias   = "eu-north-1"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,11 @@
+resource "aws_acm_certificate" "cert" {
+  domain_name               = "${var.domain}"
+  subject_alternative_names = ["${var.domain_alias}"]
+  validation_method         = "DNS"
+
+  provider = "aws.us-east-1"
+}
+
 module "aws_deploy-api_uat-eu-north-1" {
   source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.1.1"
   env               = "api_uat"
@@ -32,12 +40,12 @@ module "aws_deploy-api_uat-eu-north-1" {
 }
 
 module "aws_gateway" {
-  source    = "github.com/aeternity/terraform-aws-api-gateway?ref=v1.1.0"
+  source    = "github.com/aeternity/terraform-aws-api-gateway?ref=v2.0.0"
   dns_zone  = "${var.dns_zone}"
   api_dns   = "${var.domain}"
   api_alias = "${var.domain_alias}"
 
-  validate_cert = true
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
 
   loadbalancers = [
     "${module.aws_deploy-api_uat-eu-north-1.gateway_lb_dns}",


### PR DESCRIPTION
Make use of the certificate refactoring in https://github.com/aeternity/terraform-aws-api-gateway/pull/7

Note: This should fix deployment of "master" (https://circleci.com/gh/aeternity/terraform-aws-testnet-api/40)