### PR TITLE
Use the new terraform modules

### DIFF
--- a/aws.tf
+++ b/aws.tf
@@ -7,6 +7,12 @@ terraform {
   }
 }
 
+# Default
+provider "aws" {
+  version = "2.16.0"
+  region  = "us-east-1"
+}
+
 provider "aws" {
   version = "2.16.0"
   region  = "us-east-1"

--- a/cert.tf
+++ b/cert.tf
@@ -1,0 +1,35 @@
+resource "aws_acm_certificate" "cert" {
+  domain_name               = "${var.domain}"
+  subject_alternative_names = "${var.domain_aliases}"
+  validation_method         = "DNS"
+}
+
+resource "aws_route53_record" "cert_validation" {
+  zone_id = "${var.dns_zone}"
+  name    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
+  type    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
+  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
+  ttl     = 60
+}
+
+resource "aws_route53_record" "cert_validation_alt" {
+  zone_id = "${var.dns_zone}"
+  name    = "${aws_acm_certificate.cert.domain_validation_options.2.resource_record_name}"
+  type    = "${aws_acm_certificate.cert.domain_validation_options.2.resource_record_type}"
+  records = ["${aws_acm_certificate.cert.domain_validation_options.2.resource_record_value}"]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [
+    aws_route53_record.cert_validation.fqdn,
+    aws_route53_record.cert_validation_alt.fqdn,
+    # trim last dot as it's DNS record name
+    substr(
+      aws_acm_certificate.cert.domain_validation_options.1.resource_record_name,
+      0,
+      length(aws_acm_certificate.cert.domain_validation_options.1.resource_record_name) - 1
+    )
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -3,15 +3,19 @@ variable "vault_addr" {
 }
 
 variable "bootstrap_version" {
-  default = "v2.5.1"
+  default = "v2.6.2"
 }
 
 variable "package" {
-  default = "https://releases.ops.aeternity.com/aeternity-3.1.0-ubuntu-x86_64.tar.gz"
+  default = "https://releases.ops.aeternity.com/aeternity-4.0.0-ubuntu-x86_64.tar.gz"
 }
 
 variable "dns_zone" {
   default = "ZSEEAAX46MKWZ"
+}
+
+variable "lb_fqdn" {
+  default = "lb.testnet.aeternity.io"
 }
 
 variable "domain" {


### PR DESCRIPTION
This update adds:
- SC websockets support gateway can be used as initiator
- transactions dry-run support

Multiple configuration improvements.

Nothing to bee seen in the terraform plan (CI) as this is already applied. I applied it locally as it's non-public service yet to better test prior this PR.

The gateway URL is https://testnet.aeternity.io/v2/status